### PR TITLE
Removed all_frames line from manifest.json: defaults to false

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,7 +16,6 @@
 	},
 	"content_scripts": [
 		{
-			"all_frames": true,
 			"js": [
 				"content/content.js"
 			],


### PR DESCRIPTION
Fixes #2 
This will stop multiple instances of Codext being triggered in the background