### PR TITLE
Use the word 'Codext' in extension update notification

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -84,7 +84,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
   if (details.reason === "update") {
     chrome.notifications.create("update_notification", {
       title: "Extension update",
-      message: `Extension updated to version ${chrome.runtime.getManifest().version}`,
+      message: `Codext updated to version ${chrome.runtime.getManifest().version}`,
       type: "basic",
       iconUrl: "images/codext_logo.png"
     });

--- a/tests/spec/BackgroundSpec.js
+++ b/tests/spec/BackgroundSpec.js
@@ -121,7 +121,7 @@ describe("Background script", function() {
     expect(
       chrome.notifications.create.withArgs("update_notification", {
         title: "Extension update",
-        message: "Extension updated to version 1.0.0",
+        message: "Codext updated to version 1.0.0",
         type: "basic",
         iconUrl: "images/codext_logo.png"
       }).calledOnce


### PR DESCRIPTION
When Codext updates, the browser notification says "Extension update: Extension updated to version n.n.n" with the Codext logo. Great for sighted users, but folks using a screen reader might want to hear the name of the extension that's just been updated.

This PR adds the word "Codext" to that notification.