### PR TITLE
Added basic theme support

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -4,12 +4,18 @@ const tabIdToContentType = {};
 
 // Populate the extension's context menu with relevant items. Right-click on the
 // page action icon to open it.
-chrome.storage.local.get("disabled", function(disabledState) {
-  addNormalMenu(getDisabledStateLabel(disabledState["disabled"]), "disabled");
+chrome.storage.local.get(["disabled", "theme"], function(state) {
+  const theme = state["theme"];
+
+  addNormalMenu(getDisabledStateLabel(state["disabled"]), "disabled");
   addMenuSeparator("separator1");
+  addRadioMenu("Light Theme", "vs", theme === "vs");
+  addRadioMenu("Dark Theme", "vs-dark", theme === "vs-dark");
+  addRadioMenu("High Contrast Theme", "hc-black", theme === "hc-black");
+  addMenuSeparator("separator2");
   addNormalMenu("Homepage", "homepage");
   addNormalMenu("License", "license");
-  addMenuSeparator("separator2");
+  addMenuSeparator("separator3");
 });
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
@@ -91,11 +97,29 @@ chrome.runtime.onInstalled.addListener(function(details) {
   }
 });
 
+function selectTheme(info, tab) {
+  chrome.storage.local.set({
+    theme: info.menuItemId
+  });
+  chrome.tabs.sendMessage(tab.id, {action: "set_theme", content: info.menuItemId});
+}
+
 function addNormalMenu(menuTitle, menuId) {
   chrome.contextMenus.create({
     title: menuTitle,
     id: menuId,
     contexts: ["page_action"]
+  });
+}
+
+function addRadioMenu(menuTitle, menuId, checked) {
+  chrome.contextMenus.create({
+    title: menuTitle,
+    type: "radio",
+    checked: checked,
+    id: menuId,
+    contexts: ["page_action"],
+    onclick: selectTheme
   });
 }
 

--- a/tests/spec/EditorSpec.js
+++ b/tests/spec/EditorSpec.js
@@ -3,10 +3,10 @@
 var monaco;
 
 describe("Editor script", function() {
-  beforeEach(function() {
+  beforeEach(function(done) {
     // Dummy editor object so that we can attach spy objects in tests.
     editor = {};
-    chrome.storage.local.set.flush();
+    chrome.storage.local.clear(done);
   });
 
   it("should return supported user locale or null", function() {
@@ -43,12 +43,13 @@ describe("Editor script", function() {
       code: "code-content"
     });
 
-    expect(window.launchEditor).toHaveBeenCalledWith("code-content", false, "yaml");
+    expect(window.launchEditor).toHaveBeenCalledWith("code-content", false, "yaml", "vs");
   });
 
   it("should prepare to launch editable editor by inferring the language with the MIME type", function() {
-    chrome.storage.local.get.withArgs("editable").yields({
-      editable: "true"
+    chrome.storage.local.get.withArgs(["editable", "theme"]).yields({
+      editable: "true",
+      theme: "vs-dark"
     });
     chrome.runtime.sendMessage
       .withArgs({
@@ -71,7 +72,7 @@ describe("Editor script", function() {
       code: "code-content"
     });
 
-    expect(window.launchEditor).toHaveBeenCalledWith("code-content", true, "json");
+    expect(window.launchEditor).toHaveBeenCalledWith("code-content", true, "json", "vs-dark");
   });
 
   it("should launch editor, add actions and add resize listener", function() {
@@ -84,7 +85,7 @@ describe("Editor script", function() {
     spyOn(window, "addOrUpdateEditableAction");
     spyOn(window, "addExportAction");
 
-    launchEditor("code-content", false, "java");
+    launchEditor("code-content", false, "java", "vs");
 
     expect(monaco.editor.create).toHaveBeenCalledWith(null, {
       value: "code-content",
@@ -94,7 +95,8 @@ describe("Editor script", function() {
       folding: true,
       cursorBlinking: "smooth",
       dragAndDrop: true,
-      mouseWheelZoom: true
+      mouseWheelZoom: true,
+      theme: "vs"
     });
     expect(window.addOrUpdateEditableAction).toHaveBeenCalledWith(false);
     expect(window.addExportAction).toHaveBeenCalled();


### PR DESCRIPTION
Exposed the three default themes through the extension context menu. Includes local storage persistence.

Also amended editor test clean-up since the storage state was lingering between tests.