### PR TITLE
Fix editor height for Firefox

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -62,11 +62,13 @@ function getFilename() {
   return filename;
 }
 
-function insertEditorFrame() {
+function insertEditorFrame() {	
   const iframe = document.createElement("iframe");
   iframe.setAttribute("src", chrome.runtime.getURL("editor/editor.html"));
-  iframe.setAttribute("style", "border: 0px none; width: 100%; height: 100%;");
+  iframe.setAttribute("style", "border: 0px none; width: 100%; height: 100%; display: block;");
 
+  document.documentElement.style.height = "100%";
   document.body.style.margin = "0px";
+  document.body.style.height = "100%";
   document.body.insertBefore(iframe, document.body.firstChild);
 }

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -62,7 +62,7 @@ function getFilename() {
   return filename;
 }
 
-function insertEditorFrame() {	
+function insertEditorFrame() {
   const iframe = document.createElement("iframe");
   iframe.setAttribute("src", chrome.runtime.getURL("editor/editor.html"));
   iframe.setAttribute("style", "border: 0px none; width: 100%; height: 100%; display: block;");

--- a/tests/spec/ContentSpec.js
+++ b/tests/spec/ContentSpec.js
@@ -78,7 +78,7 @@ describe("Content script", function () {
 
     const builtIframe = document.body.insertBefore.calls.mostRecent().args[0];
     expect(builtIframe.src).toContain("runtime-url/editor/editor.html");
-    expect(builtIframe.style.cssText).toEqual("border: 0px none; width: 100%; height: 100%;");
+    expect(builtIframe.style.cssText).toEqual("border: 0px none; width: 100%; height: 100%; display: block;");
     expect(document.body.style.margin).toEqual("0px");
   });
 


### PR DESCRIPTION
In Firefox 94 the editor no longer fills the page. I resolved this by setting the height of all elements to 100% all the way from the html node to the iframe node. To make sure the iframe does not get a scrollbar we need to set its display style to block.